### PR TITLE
Add advancements/recipes json files

### DIFF
--- a/src/main/java/com/drewhannay/lanterncolors/datagen/Recipes.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/Recipes.java
@@ -2,16 +2,14 @@ package com.drewhannay.lanterncolors.datagen;
 
 import com.drewhannay.lanterncolors.LanternColors;
 import com.drewhannay.lanterncolors.blocks.ColoredLanternBlocks;
-import net.minecraft.block.Blocks;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.IFinishedRecipe;
+import net.minecraft.data.RecipeProvider;
 import net.minecraft.data.ShapelessRecipeBuilder;
-import net.minecraftforge.common.Tags;
-import net.minecraftforge.common.data.ForgeRecipeProvider;
 
 import java.util.function.Consumer;
 
-public class Recipes extends ForgeRecipeProvider {
+public class Recipes extends RecipeProvider {
 
     public Recipes(DataGenerator generatorIn) {
         super(generatorIn);
@@ -23,8 +21,7 @@ public class Recipes extends ForgeRecipeProvider {
             ShapelessRecipeBuilder.shapelessRecipe(block)
                                   .addIngredient(ItemTags.glassPaneTagForDyeColor(block.getDyeColor()))
                                   .addIngredient(ItemTags.LANTERNS)
-                                  .addCriterion("has_lantern", hasItem(Blocks.LANTERN))
-                                  .addCriterion("has_glass_pane", hasItem(Tags.Items.GLASS_PANES))
+                                  .addCriterion("has_lantern", hasItem(ItemTags.LANTERNS))
                                   .build(consumer);
         });
     }

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/black_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/black_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:black_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:black_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/blue_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/blue_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:blue_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:blue_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/brown_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/brown_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:brown_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:brown_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/cyan_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/cyan_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:cyan_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:cyan_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/gray_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/gray_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:gray_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:gray_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/green_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/green_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:green_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:green_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/light_blue_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/light_blue_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:light_blue_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:light_blue_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/light_gray_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/light_gray_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:light_gray_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:light_gray_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/lime_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/lime_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:lime_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:lime_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/magenta_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/magenta_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:magenta_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:magenta_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/orange_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/orange_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:orange_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:orange_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/pink_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/pink_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:pink_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:pink_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/purple_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/purple_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:purple_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:purple_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/red_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/red_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:red_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:red_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/white_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/white_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:white_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:white_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/lanterncolors/advancements/recipes/decorations/yellow_coloredlantern.json
+++ b/src/main/resources/data/lanterncolors/advancements/recipes/decorations/yellow_coloredlantern.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "lanterncolors:yellow_coloredlantern"
+    ]
+  },
+  "criteria": {
+    "has_lantern": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "lanterncolors:lanterns"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "lanterncolors:yellow_coloredlantern"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lantern",
+      "has_the_recipe"
+    ]
+  ]
+}


### PR DESCRIPTION
Turns out you're supposed to directly extend the Minecraft
RecipeProvider rather than extending the ForgeRecipeProvider class. The
Forge one overrides the saveRecipeAdvancement method to do nothing, so
these json files were never generated and the custom recipes weren't
showing up in the in-game recipe book when you got the correct
materials.

Now we extend the correct class in our generator and the files are
properly created. This also adjusts the criterion so that you only need
to have a lantern to unlock the recipes and not glass panes.