### PR TITLE
Update to 1.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200514-1.15.1'
+    mappings channel: 'snapshot', version: '20200707-1.16.1'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -99,7 +99,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.15.2-31.2.0'
+    minecraft 'net.minecraftforge:forge:1.16.1-32.0.67'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-lantern_colors_version=1.0.1
-mc_version=1.15.2
-jei_version=6.0.0.2
+lantern_colors_version=2.0.0
+mc_version=1.16.1
+jei_version=7.0.0.6

--- a/src/main/java/com/drewhannay/lanterncolors/blocks/ColoredLanternBlock.java
+++ b/src/main/java/com/drewhannay/lanterncolors/blocks/ColoredLanternBlock.java
@@ -15,15 +15,16 @@ public class ColoredLanternBlock extends LanternBlock {
         super(
             Block.Properties.create(Material.IRON)
                             .hardnessAndResistance(3.5F)
+                            .setRequiresTool()
                             .sound(SoundType.LANTERN)
-                            .lightValue(15)
+                            .setLightLevel((blockState) -> 15)
                             .notSolid()
         );
         this.color = color;
     }
 
     public String registryName() {
-        return color.getName() + "_coloredlantern";
+        return color.getString() + "_coloredlantern";
     }
 
     public DyeColor getDyeColor() {

--- a/src/main/java/com/drewhannay/lanterncolors/blocks/ColoredLanternBlocks.java
+++ b/src/main/java/com/drewhannay/lanterncolors/blocks/ColoredLanternBlocks.java
@@ -14,8 +14,8 @@ import java.util.stream.Stream;
 
 public final class ColoredLanternBlocks {
 
-    public static final DeferredRegister<Block> REGISTRY =
-        new DeferredRegister<>(ForgeRegistries.BLOCKS, LanternColors.MODID);
+    public static final DeferredRegister<Block> REGISTRY
+        = DeferredRegister.create(ForgeRegistries.BLOCKS, LanternColors.MODID);
 
     private static final Map<DyeColor, RegistryObject<ColoredLanternBlock>> REGISTRY_OBJECTS
         = new EnumMap<>(DyeColor.class);

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/BlockStates.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/BlockStates.java
@@ -8,7 +8,6 @@ import net.minecraftforge.client.model.generators.BlockModelBuilder;
 import net.minecraftforge.client.model.generators.BlockStateProvider;
 import net.minecraftforge.client.model.generators.ConfiguredModel;
 import net.minecraftforge.client.model.generators.ExistingFileHelper;
-import net.minecraftforge.client.model.generators.ModelFile;
 
 import javax.annotation.Nonnull;
 
@@ -24,15 +23,13 @@ public class BlockStates extends BlockStateProvider {
         ColoredLanternBlocks.getBlocks().forEach(block -> {
             BlockModelBuilder modelLantern =
                 models().getBuilder(block.getRegistryName().getPath())
-                        .parent(new ModelFile.UncheckedModelFile(mcLoc("block/lantern")))
-                        .texture("particle", modLoc("block/" + block.registryName()))
-                        .texture("all", modLoc("block/" + block.registryName()));
+                        .parent(models().getExistingFile(mcLoc("block/template_lantern")))
+                        .texture("lantern", modLoc("block/" + block.registryName()));
 
             BlockModelBuilder modelHangingLantern =
                 models().getBuilder(block.getRegistryName().getPath().replace("_coloredlantern", "_hanging_coloredlantern"))
-                        .parent(new ModelFile.UncheckedModelFile(mcLoc("block/hanging_lantern")))
-                        .texture("particle", modLoc("block/" + block.registryName()))
-                        .texture("all", modLoc("block/" + block.registryName()));
+                        .parent(models().getExistingFile(mcLoc("block/template_hanging_lantern")))
+                        .texture("lantern", modLoc("block/" + block.registryName()));
 
             getVariantBuilder(block).forAllStates(state -> {
                 BlockModelBuilder model;

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/BlockTags.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/BlockTags.java
@@ -6,13 +6,11 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.data.BlockTagsProvider;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.tags.Tag;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.tags.ITag;
 
 public class BlockTags extends BlockTagsProvider {
 
-    public static final Tag<Block> LANTERNS =
-        new net.minecraft.tags.BlockTags.Wrapper(new ResourceLocation(LanternColors.MODID, "lanterns"));
+    public static final ITag.INamedTag<Block> LANTERNS = net.minecraft.tags.BlockTags.makeWrapperTag(LanternColors.MODID + ":lanterns");
 
     public BlockTags(DataGenerator generatorIn) {
         super(generatorIn);
@@ -20,8 +18,8 @@ public class BlockTags extends BlockTagsProvider {
 
     @Override
     protected void registerTags() {
-        Tag.Builder<Block> builder = getBuilder(LANTERNS).add(Blocks.LANTERN);
-        ColoredLanternBlocks.getBlocks().forEach(builder::add);
+        Builder<Block> builder = func_240522_a_(LANTERNS).func_240532_a_(Blocks.LANTERN);
+        ColoredLanternBlocks.getBlocks().forEach(builder::func_240532_a_);
     }
 
     @Override

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/DataGenerators.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/DataGenerators.java
@@ -15,8 +15,9 @@ public class DataGenerators {
         if (event.includeServer()) {
             generator.addProvider(new Recipes(generator));
             generator.addProvider(new LootTables(generator));
-            generator.addProvider(new BlockTags(generator));
-            generator.addProvider(new ItemTags(generator));
+            BlockTags blockTagsProvider = new BlockTags(generator);
+            generator.addProvider(blockTagsProvider);
+            generator.addProvider(new ItemTags(generator, blockTagsProvider));
         }
         if (event.includeClient()) {
             generator.addProvider(new BlockStates(generator, event.getExistingFileHelper()));

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/ItemTags.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/ItemTags.java
@@ -2,28 +2,27 @@ package com.drewhannay.lanterncolors.datagen;
 
 import com.drewhannay.lanterncolors.LanternColors;
 import com.drewhannay.lanterncolors.items.ColoredLanternItems;
+import net.minecraft.data.BlockTagsProvider;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.ItemTagsProvider;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
-import net.minecraft.tags.Tag;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.tags.ITag;
 import net.minecraftforge.common.Tags;
 
 public class ItemTags extends ItemTagsProvider {
 
-    public static final Tag<Item> LANTERNS =
-        new net.minecraft.tags.ItemTags.Wrapper(new ResourceLocation(LanternColors.MODID, "lanterns"));
+    public static final ITag.INamedTag<Item> LANTERNS = net.minecraft.tags.ItemTags.makeWrapperTag(LanternColors.MODID + ":lanterns");
 
-    public ItemTags(DataGenerator generatorIn) {
-        super(generatorIn);
+    public ItemTags(DataGenerator generatorIn, BlockTagsProvider blockTagsProvider) {
+        super(generatorIn, blockTagsProvider);
     }
 
     @Override
     protected void registerTags() {
-        Tag.Builder<Item> builder = getBuilder(LANTERNS).add(Items.LANTERN);
-        ColoredLanternItems.getItems().forEach(builder::add);
+        Builder<Item> builder = func_240522_a_(LANTERNS).func_240532_a_(Items.LANTERN);
+        ColoredLanternItems.getItems().forEach(builder::func_240532_a_);
     }
 
     @Override
@@ -32,7 +31,7 @@ public class ItemTags extends ItemTagsProvider {
     }
 
     // TODO: Is there an existing helper for this?
-    public static Tag<Item> glassPaneTagForDyeColor(DyeColor color) {
+    public static ITag.INamedTag<Item> glassPaneTagForDyeColor(DyeColor color) {
         switch (color) {
             case WHITE:
                 return Tags.Items.GLASS_PANES_WHITE;

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/Languages.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/Languages.java
@@ -29,6 +29,6 @@ public class Languages extends LanguageProvider {
     }
 
     private String getTranslationName(DyeColor color) {
-        return Arrays.stream(StringUtils.split(color.getName(), "_")).map(StringUtils::capitalise).collect(Collectors.joining(" "));
+        return Arrays.stream(StringUtils.split(color.getString(), "_")).map(StringUtils::capitalise).collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/drewhannay/lanterncolors/datagen/LootTables.java
+++ b/src/main/java/com/drewhannay/lanterncolors/datagen/LootTables.java
@@ -8,11 +8,11 @@ import net.minecraft.block.Block;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.LootTableProvider;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.storage.loot.LootParameterSet;
-import net.minecraft.world.storage.loot.LootParameterSets;
-import net.minecraft.world.storage.loot.LootTable;
-import net.minecraft.world.storage.loot.LootTableManager;
-import net.minecraft.world.storage.loot.ValidationTracker;
+import net.minecraft.loot.LootParameterSet;
+import net.minecraft.loot.LootParameterSets;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.LootTableManager;
+import net.minecraft.loot.ValidationTracker;
 import net.minecraftforge.fml.RegistryObject;
 
 import java.util.List;

--- a/src/main/java/com/drewhannay/lanterncolors/items/ColoredLanternItems.java
+++ b/src/main/java/com/drewhannay/lanterncolors/items/ColoredLanternItems.java
@@ -18,8 +18,8 @@ import java.util.stream.Stream;
 
 public final class ColoredLanternItems {
 
-    public static final DeferredRegister<Item> REGISTRY =
-        new DeferredRegister<>(ForgeRegistries.ITEMS, LanternColors.MODID);
+    public static final DeferredRegister<Item> REGISTRY
+        = DeferredRegister.create(ForgeRegistries.ITEMS, LanternColors.MODID);
 
     private static final Map<DyeColor, RegistryObject<BlockItem>> REGISTRY_OBJECTS = new EnumMap<>(DyeColor.class);
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml" #mandatory
-loaderVersion="[31,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[32,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 issueTrackerURL="https://github.com/drewhannay/lantern-colors/issues" #optional
 [[mods]] #mandatory
 modId="lanterncolors" #mandatory
@@ -18,13 +18,13 @@ This mod adds lantern variants for every dye color.
 [[dependencies.lanterncolors]] #optional
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[31,)" #mandatory
+    versionRange="[32,)" #mandatory
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.lanterncolors]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.15.2]"
+    versionRange="[1.16.1]"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/assets/lanterncolors/models/block/black_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/black_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/black_coloredlantern",
-    "all": "lanterncolors:block/black_coloredlantern"
+    "lantern": "lanterncolors:block/black_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/black_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/black_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/black_coloredlantern",
-    "all": "lanterncolors:block/black_coloredlantern"
+    "lantern": "lanterncolors:block/black_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/blue_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/blue_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/blue_coloredlantern",
-    "all": "lanterncolors:block/blue_coloredlantern"
+    "lantern": "lanterncolors:block/blue_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/blue_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/blue_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/blue_coloredlantern",
-    "all": "lanterncolors:block/blue_coloredlantern"
+    "lantern": "lanterncolors:block/blue_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/brown_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/brown_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/brown_coloredlantern",
-    "all": "lanterncolors:block/brown_coloredlantern"
+    "lantern": "lanterncolors:block/brown_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/brown_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/brown_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/brown_coloredlantern",
-    "all": "lanterncolors:block/brown_coloredlantern"
+    "lantern": "lanterncolors:block/brown_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/cyan_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/cyan_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/cyan_coloredlantern",
-    "all": "lanterncolors:block/cyan_coloredlantern"
+    "lantern": "lanterncolors:block/cyan_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/cyan_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/cyan_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/cyan_coloredlantern",
-    "all": "lanterncolors:block/cyan_coloredlantern"
+    "lantern": "lanterncolors:block/cyan_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/gray_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/gray_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/gray_coloredlantern",
-    "all": "lanterncolors:block/gray_coloredlantern"
+    "lantern": "lanterncolors:block/gray_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/gray_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/gray_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/gray_coloredlantern",
-    "all": "lanterncolors:block/gray_coloredlantern"
+    "lantern": "lanterncolors:block/gray_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/green_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/green_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/green_coloredlantern",
-    "all": "lanterncolors:block/green_coloredlantern"
+    "lantern": "lanterncolors:block/green_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/green_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/green_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/green_coloredlantern",
-    "all": "lanterncolors:block/green_coloredlantern"
+    "lantern": "lanterncolors:block/green_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/light_blue_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/light_blue_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/light_blue_coloredlantern",
-    "all": "lanterncolors:block/light_blue_coloredlantern"
+    "lantern": "lanterncolors:block/light_blue_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/light_blue_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/light_blue_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/light_blue_coloredlantern",
-    "all": "lanterncolors:block/light_blue_coloredlantern"
+    "lantern": "lanterncolors:block/light_blue_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/light_gray_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/light_gray_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/light_gray_coloredlantern",
-    "all": "lanterncolors:block/light_gray_coloredlantern"
+    "lantern": "lanterncolors:block/light_gray_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/light_gray_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/light_gray_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/light_gray_coloredlantern",
-    "all": "lanterncolors:block/light_gray_coloredlantern"
+    "lantern": "lanterncolors:block/light_gray_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/lime_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/lime_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/lime_coloredlantern",
-    "all": "lanterncolors:block/lime_coloredlantern"
+    "lantern": "lanterncolors:block/lime_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/lime_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/lime_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/lime_coloredlantern",
-    "all": "lanterncolors:block/lime_coloredlantern"
+    "lantern": "lanterncolors:block/lime_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/magenta_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/magenta_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/magenta_coloredlantern",
-    "all": "lanterncolors:block/magenta_coloredlantern"
+    "lantern": "lanterncolors:block/magenta_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/magenta_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/magenta_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/magenta_coloredlantern",
-    "all": "lanterncolors:block/magenta_coloredlantern"
+    "lantern": "lanterncolors:block/magenta_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/orange_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/orange_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/orange_coloredlantern",
-    "all": "lanterncolors:block/orange_coloredlantern"
+    "lantern": "lanterncolors:block/orange_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/orange_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/orange_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/orange_coloredlantern",
-    "all": "lanterncolors:block/orange_coloredlantern"
+    "lantern": "lanterncolors:block/orange_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/pink_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/pink_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/pink_coloredlantern",
-    "all": "lanterncolors:block/pink_coloredlantern"
+    "lantern": "lanterncolors:block/pink_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/pink_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/pink_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/pink_coloredlantern",
-    "all": "lanterncolors:block/pink_coloredlantern"
+    "lantern": "lanterncolors:block/pink_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/purple_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/purple_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/purple_coloredlantern",
-    "all": "lanterncolors:block/purple_coloredlantern"
+    "lantern": "lanterncolors:block/purple_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/purple_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/purple_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/purple_coloredlantern",
-    "all": "lanterncolors:block/purple_coloredlantern"
+    "lantern": "lanterncolors:block/purple_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/red_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/red_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/red_coloredlantern",
-    "all": "lanterncolors:block/red_coloredlantern"
+    "lantern": "lanterncolors:block/red_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/red_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/red_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/red_coloredlantern",
-    "all": "lanterncolors:block/red_coloredlantern"
+    "lantern": "lanterncolors:block/red_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/white_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/white_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/white_coloredlantern",
-    "all": "lanterncolors:block/white_coloredlantern"
+    "lantern": "lanterncolors:block/white_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/white_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/white_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/white_coloredlantern",
-    "all": "lanterncolors:block/white_coloredlantern"
+    "lantern": "lanterncolors:block/white_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/yellow_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/yellow_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/lantern",
+  "parent": "block/template_lantern",
   "textures": {
-    "particle": "lanterncolors:block/yellow_coloredlantern",
-    "all": "lanterncolors:block/yellow_coloredlantern"
+    "lantern": "lanterncolors:block/yellow_coloredlantern"
   }
 }

--- a/src/main/resources/assets/lanterncolors/models/block/yellow_hanging_coloredlantern.json
+++ b/src/main/resources/assets/lanterncolors/models/block/yellow_hanging_coloredlantern.json
@@ -1,7 +1,6 @@
 {
-  "parent": "block/hanging_lantern",
+  "parent": "block/template_hanging_lantern",
   "textures": {
-    "particle": "lanterncolors:block/yellow_coloredlantern",
-    "all": "lanterncolors:block/yellow_coloredlantern"
+    "lantern": "lanterncolors:block/yellow_coloredlantern"
   }
 }


### PR DESCRIPTION
Notable changes:
- There's now a base lantern template model since Vanilla has 2 lanterns
- Added extra validation that the vanilla models we depend on actually
  exist by using models().getExistingFile()