### PR TITLE
mark as 1.16.3 compatible

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -26,6 +26,6 @@ This mod adds lantern variants for every dye color.
 [[dependencies.lanterncolors]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.2]"
+    versionRange="[1.16.2,1.16.3]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Extend the minecraft range 
from exaxt 1.16.2 `[1.16.2]`
to the range 1.16.2 -> 1.16.3 `[1.16.2,1.16.3]` 

Other options are:
* 1.16.2 -> 1.16.* `[1.16.2,1.17)`
* 1.16.2 -> * `[1.16.2,)`